### PR TITLE
feat: phase 4 advanced pm features (#3)

### DIFF
--- a/app/Filament/Resources/NotificationResource.php
+++ b/app/Filament/Resources/NotificationResource.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\NotificationResource\Pages\ListNotifications;
+use App\Models\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Builder;
+
+class NotificationResource extends Resource
+{
+    protected static ?string $model = Notification::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-bell';
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('type')->searchable(),
+                TextColumn::make('user.email')->label('User'),
+                TextColumn::make('read_at')->dateTime(),
+                TextColumn::make('created_at')->dateTime(),
+            ])
+            ->actions([]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return parent::getEloquentQuery()->whereRaw('1 = 0');
+        }
+
+        return parent::getEloquentQuery()
+            ->whereHas('user.workspaces', function (Builder $query) use ($user) {
+                $query->where('users.id', $user->id)
+                    ->whereIn('workspace_user.role', ['owner', 'admin']);
+            });
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListNotifications::route('/'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Resources/NotificationResource/Pages/ListNotifications.php
+++ b/app/Filament/Resources/NotificationResource/Pages/ListNotifications.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\NotificationResource\Pages;
+
+use App\Filament\Resources\NotificationResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListNotifications extends ListRecords
+{
+    protected static string $resource = NotificationResource::class;
+}

--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ProjectResource\Pages\CreateProject;
+use App\Filament\Resources\ProjectResource\Pages\EditProject;
+use App\Filament\Resources\ProjectResource\Pages\ListProjects;
+use App\Filament\Resources\ProjectResource\RelationManagers\MembersRelationManager;
+use App\Models\Project;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Builder;
+
+class ProjectResource extends Resource
+{
+    protected static ?string $model = Project::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-briefcase';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+            TextInput::make('description')
+                ->maxLength(500),
+            Select::make('workspace_id')
+                ->relationship('workspace', 'name')
+                ->searchable()
+                ->required(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('workspace.name')->label('Workspace'),
+                TextColumn::make('created_at')->dateTime(),
+            ])
+            ->actions([
+                EditAction::make(),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return parent::getEloquentQuery()->whereRaw('1 = 0');
+        }
+
+        return parent::getEloquentQuery()
+            ->whereHas('workspace.members', function (Builder $query) use ($user) {
+                $query->where('users.id', $user->id)
+                    ->whereIn('workspace_user.role', ['owner', 'admin']);
+            });
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            MembersRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListProjects::route('/'),
+            'create' => CreateProject::route('/create'),
+            'edit' => EditProject::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ProjectResource/Pages/CreateProject.php
+++ b/app/Filament/Resources/ProjectResource/Pages/CreateProject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProjectResource\Pages;
+
+use App\Filament\Resources\ProjectResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateProject extends CreateRecord
+{
+    protected static string $resource = ProjectResource::class;
+}

--- a/app/Filament/Resources/ProjectResource/Pages/EditProject.php
+++ b/app/Filament/Resources/ProjectResource/Pages/EditProject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProjectResource\Pages;
+
+use App\Filament\Resources\ProjectResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditProject extends EditRecord
+{
+    protected static string $resource = ProjectResource::class;
+}

--- a/app/Filament/Resources/ProjectResource/Pages/ListProjects.php
+++ b/app/Filament/Resources/ProjectResource/Pages/ListProjects.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ProjectResource\Pages;
+
+use App\Filament\Resources\ProjectResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListProjects extends ListRecords
+{
+    protected static string $resource = ProjectResource::class;
+}

--- a/app/Filament/Resources/ProjectResource/RelationManagers/MembersRelationManager.php
+++ b/app/Filament/Resources/ProjectResource/RelationManagers/MembersRelationManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources\ProjectResource\RelationManagers;
+
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
+use Filament\Forms\Components\Select;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+
+class MembersRelationManager extends RelationManager
+{
+    protected static string $relationship = 'members';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Select::make('role')
+                ->options([
+                    'manager' => 'Manager',
+                    'contributor' => 'Contributor',
+                    'viewer' => 'Viewer',
+                ])
+                ->required(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('email')->searchable(),
+                TextColumn::make('pivot.role')->label('Role'),
+            ])
+            ->headerActions([
+                AttachAction::make()
+                    ->form([
+                        Select::make('role')
+                            ->options([
+                                'manager' => 'Manager',
+                                'contributor' => 'Contributor',
+                                'viewer' => 'Viewer',
+                            ])
+                            ->required(),
+                    ]),
+            ])
+            ->actions([
+                DetachAction::make(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/SprintResource.php
+++ b/app/Filament/Resources/SprintResource.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SprintResource\Pages\CreateSprint;
+use App\Filament\Resources\SprintResource\Pages\EditSprint;
+use App\Filament\Resources\SprintResource\Pages\ListSprints;
+use App\Models\Sprint;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+use Filament\Tables\Columns\TextColumn;
+use Illuminate\Database\Eloquent\Builder;
+
+class SprintResource extends Resource
+{
+    protected static ?string $model = Sprint::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-flag';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Select::make('project_id')
+                ->relationship('project', 'name')
+                ->searchable()
+                ->required(),
+            TextInput::make('name')
+                ->required()
+                ->maxLength(255),
+            TextInput::make('goal')
+                ->maxLength(500),
+            Select::make('status')
+                ->options([
+                    'planned' => 'Planned',
+                    'active' => 'Active',
+                    'completed' => 'Completed',
+                ])
+                ->required(),
+            DateTimePicker::make('starts_at'),
+            DateTimePicker::make('ends_at'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('project.name')->label('Project'),
+                TextColumn::make('status'),
+                TextColumn::make('starts_at')->dateTime(),
+                TextColumn::make('ends_at')->dateTime(),
+            ])
+            ->actions([
+                EditAction::make(),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return parent::getEloquentQuery()->whereRaw('1 = 0');
+        }
+
+        return parent::getEloquentQuery()
+            ->whereHas('project.workspace.members', function (Builder $query) use ($user) {
+                $query->where('users.id', $user->id)
+                    ->whereIn('workspace_user.role', ['owner', 'admin']);
+            });
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListSprints::route('/'),
+            'create' => CreateSprint::route('/create'),
+            'edit' => EditSprint::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SprintResource/Pages/CreateSprint.php
+++ b/app/Filament/Resources/SprintResource/Pages/CreateSprint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSprint extends CreateRecord
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Filament/Resources/SprintResource/Pages/EditSprint.php
+++ b/app/Filament/Resources/SprintResource/Pages/EditSprint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSprint extends EditRecord
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Filament/Resources/SprintResource/Pages/ListSprints.php
+++ b/app/Filament/Resources/SprintResource/Pages/ListSprints.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\SprintResource\Pages;
+
+use App\Filament\Resources\SprintResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSprints extends ListRecords
+{
+    protected static string $resource = SprintResource::class;
+}

--- a/app/Http/Controllers/Api/BacklogController.php
+++ b/app/Http/Controllers/Api/BacklogController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ReorderBacklogRequest;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Services\IssueScheduler;
+use App\Support\ApiResponse;
+
+class BacklogController extends Controller
+{
+    public function reorder(ReorderBacklogRequest $request, Project $project, IssueScheduler $scheduler)
+    {
+        $this->authorize('update', $project);
+
+        $data = $request->validated();
+        $issue = Issue::findOrFail($data['issue_id']);
+
+        $assignment = $scheduler->moveWithinBacklog($project, $issue, $data['to_position']);
+
+        return ApiResponse::success(['backlog_item' => $assignment]);
+    }
+}

--- a/app/Http/Controllers/Api/IssueCommentController.php
+++ b/app/Http/Controllers/Api/IssueCommentController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\StoreCommentRequest;
 use App\Models\Comment;
 use App\Models\Issue;
 use App\Services\ActivityLogger;
+use App\Services\NotificationService;
 use App\Support\ApiResponse;
 
 class IssueCommentController extends Controller
@@ -23,7 +24,7 @@ class IssueCommentController extends Controller
         return ApiResponse::success(['comments' => $comments]);
     }
 
-    public function store(StoreCommentRequest $request, Issue $issue, ActivityLogger $activityLogger)
+    public function store(StoreCommentRequest $request, Issue $issue, ActivityLogger $activityLogger, NotificationService $notifications)
     {
         $comment = new Comment(['issue_id' => $issue->id]);
         $comment->setRelation('issue', $issue);
@@ -37,6 +38,7 @@ class IssueCommentController extends Controller
         ]);
 
         $activityLogger->issueCommented($request->user(), $created);
+        $notifications->issueCommented($issue, $request->user());
 
         return ApiResponse::success(['comment' => $created], 201);
     }

--- a/app/Http/Controllers/Api/IssueController.php
+++ b/app/Http/Controllers/Api/IssueController.php
@@ -12,6 +12,8 @@ use App\Models\Issue;
 use App\Models\User;
 use App\Services\ActivityLogger;
 use App\Services\IssueMover;
+use App\Services\IssueScheduler;
+use App\Services\NotificationService;
 use App\Support\ApiResponse;
 use App\Support\WorkspaceAccess;
 use Illuminate\Database\Eloquent\Builder;
@@ -58,7 +60,7 @@ class IssueController extends Controller
         return ApiResponse::success(['columns' => $columns]);
     }
 
-    public function store(StoreIssueRequest $request, Board $board, ActivityLogger $activityLogger)
+    public function store(StoreIssueRequest $request, Board $board, ActivityLogger $activityLogger, IssueScheduler $scheduler)
     {
         $this->authorize('create', $board);
 
@@ -69,8 +71,13 @@ class IssueController extends Controller
             return ApiResponse::error('Board has no columns.', 'no_columns', 422);
         }
 
-        if (! $board->columns()->where('id', $columnId)->exists()) {
+        $column = $board->columns()->where('id', $columnId)->first();
+        if (! $column) {
             return ApiResponse::error('Column not found on board.', 'column_not_found', 404);
+        }
+
+        if (! $this->canAcceptIssue($column->id, $column->wip_limit)) {
+            return ApiResponse::error('WIP limit reached.', 'wip_limit_reached', 422);
         }
 
         $position = $board->issues()
@@ -87,11 +94,12 @@ class IssueController extends Controller
         ]);
 
         $activityLogger->issueCreated($request->user(), $issue);
+        $scheduler->assignToBacklog($board->project, $issue);
 
         return ApiResponse::success(['issue' => $issue], 201);
     }
 
-    public function update(UpdateIssueRequest $request, Issue $issue, IssueMover $issueMover, ActivityLogger $activityLogger)
+    public function update(UpdateIssueRequest $request, Issue $issue, IssueMover $issueMover, ActivityLogger $activityLogger, NotificationService $notifications)
     {
         $this->authorize('update', $issue);
 
@@ -107,8 +115,13 @@ class IssueController extends Controller
         $fromPosition = $issue->position;
 
         if (array_key_exists('column_id', $data) && $data['column_id'] !== $issue->column_id) {
-            if (! $issue->board->columns()->where('id', $data['column_id'])->exists()) {
+            $targetColumn = $issue->board->columns()->where('id', $data['column_id'])->first();
+            if (! $targetColumn) {
                 return ApiResponse::error('Column not found on board.', 'column_not_found', 404);
+            }
+
+            if (! $this->canAcceptIssue($targetColumn->id, $targetColumn->wip_limit)) {
+                return ApiResponse::error('WIP limit reached.', 'wip_limit_reached', 422);
             }
 
             $targetPosition = ($issue->board->issues()
@@ -132,6 +145,11 @@ class IssueController extends Controller
                 'from_position' => $fromPosition,
                 'to_position' => $issue->position,
             ]);
+
+            $issue->load('column');
+            if ($issue->column?->key === 'done') {
+                $notifications->issueMovedToDone($issue, $request->user());
+            }
         }
 
         if ($requestId) {
@@ -141,7 +159,7 @@ class IssueController extends Controller
         return ApiResponse::success(['issue' => $issue->fresh()]);
     }
 
-    public function move(MoveIssueRequest $request, Issue $issue, IssueMover $issueMover, ActivityLogger $activityLogger)
+    public function move(MoveIssueRequest $request, Issue $issue, IssueMover $issueMover, ActivityLogger $activityLogger, NotificationService $notifications)
     {
         $this->authorize('move', $issue);
 
@@ -155,6 +173,15 @@ class IssueController extends Controller
         $fromColumnId = $issue->column_id;
         $fromPosition = $issue->position;
 
+        $targetColumn = $issue->board->columns()->where('id', $data['to_column_id'])->first();
+        if (! $targetColumn) {
+            return ApiResponse::error('Column not found on board.', 'column_not_found', 404);
+        }
+
+        if ($targetColumn->id !== $issue->column_id && ! $this->canAcceptIssue($targetColumn->id, $targetColumn->wip_limit)) {
+            return ApiResponse::error('WIP limit reached.', 'wip_limit_reached', 422);
+        }
+
         $issue = $issueMover->move($issue, $data['to_column_id'], $data['to_position']);
 
         if ($fromColumnId !== $issue->column_id || $fromPosition !== $issue->position) {
@@ -164,6 +191,11 @@ class IssueController extends Controller
                 'from_position' => $fromPosition,
                 'to_position' => $issue->position,
             ]);
+
+            $issue->load('column');
+            if ($issue->column?->key === 'done') {
+                $notifications->issueMovedToDone($issue, $request->user());
+            }
         }
 
         if ($requestId) {
@@ -193,6 +225,13 @@ class IssueController extends Controller
 
         $activityLogger->issueAssigned($request->user(), $issue, $fromUserId, $assigneeId);
 
+        if ($assigneeId) {
+            $assignee = User::find($assigneeId);
+            if ($assignee) {
+                app(NotificationService::class)->issueAssigned($assignee, $issue, $request->user());
+            }
+        }
+
         return ApiResponse::success(['issue' => $issue->fresh()]);
     }
 
@@ -205,6 +244,17 @@ class IssueController extends Controller
         $issue->delete();
 
         return ApiResponse::success(['deleted' => true]);
+    }
+
+    protected function canAcceptIssue(string $columnId, ?int $wipLimit): bool
+    {
+        if (! $wipLimit) {
+            return true;
+        }
+
+        $count = Issue::where('column_id', $columnId)->count();
+
+        return $count < $wipLimit;
     }
 
     protected function applyFilters(Builder|Relation $query, array $params): void

--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Notification;
+use App\Support\ApiResponse;
+
+class NotificationController extends Controller
+{
+    public function index()
+    {
+        $notifications = request()->user()
+            ->notifications()
+            ->orderByDesc('created_at')
+            ->paginate(20);
+
+        return ApiResponse::success(['notifications' => $notifications]);
+    }
+
+    public function read(Notification $notification)
+    {
+        $this->authorize('update', $notification);
+
+        $notification->update(['read_at' => now()]);
+
+        return ApiResponse::success(['notification' => $notification->fresh()]);
+    }
+
+    public function readAll()
+    {
+        $user = request()->user();
+        $user->notifications()->whereNull('read_at')->update(['read_at' => now()]);
+
+        return ApiResponse::success(['read' => true]);
+    }
+}

--- a/app/Http/Controllers/Api/ProjectMemberController.php
+++ b/app/Http/Controllers/Api/ProjectMemberController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreProjectMemberRequest;
+use App\Http\Requests\UpdateProjectMemberRequest;
+use App\Models\Project;
+use App\Models\User;
+use App\Support\ApiResponse;
+use App\Support\ProjectAccess;
+
+class ProjectMemberController extends Controller
+{
+    public function index(Project $project)
+    {
+        $this->authorize('view', $project);
+
+        $members = $project->members()
+            ->withPivot('role')
+            ->get();
+
+        return ApiResponse::success(['members' => $members]);
+    }
+
+    public function store(StoreProjectMemberRequest $request, Project $project)
+    {
+        $this->authorize('update', $project);
+
+        $data = $request->validated();
+        $user = User::findOrFail($data['user_id']);
+
+        if (! ProjectAccess::canViewProject($user, $project) && ! $project->workspace->members()->where('user_id', $user->id)->exists()) {
+            return ApiResponse::error('User must be a workspace member.', 'not_member', 422);
+        }
+
+        $project->members()->syncWithoutDetaching([
+            $user->id => ['role' => $data['role']],
+        ]);
+
+        return ApiResponse::success(['members' => $project->members()->get()]);
+    }
+
+    public function update(UpdateProjectMemberRequest $request, Project $project, User $user)
+    {
+        $this->authorize('update', $project);
+
+        $project->members()->updateExistingPivot($user->id, [
+            'role' => $request->validated()['role'],
+        ]);
+
+        return ApiResponse::success(['members' => $project->members()->get()]);
+    }
+
+    public function destroy(Project $project, User $user)
+    {
+        $this->authorize('update', $project);
+
+        $project->members()->detach($user->id);
+
+        return ApiResponse::success(['deleted' => true]);
+    }
+}

--- a/app/Http/Controllers/Api/SprintController.php
+++ b/app/Http/Controllers/Api/SprintController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreSprintRequest;
+use App\Http\Requests\UpdateSprintRequest;
+use App\Models\Project;
+use App\Models\Sprint;
+use App\Services\IssueScheduler;
+use App\Services\NotificationService;
+use App\Services\SprintLifecycleService;
+use App\Support\ApiResponse;
+
+class SprintController extends Controller
+{
+    public function index(Project $project)
+    {
+        $this->authorize('view', $project);
+
+        $sprints = $project->sprints()
+            ->orderByDesc('starts_at')
+            ->orderByDesc('created_at')
+            ->get();
+
+        return ApiResponse::success(['sprints' => $sprints]);
+    }
+
+    public function store(StoreSprintRequest $request, Project $project)
+    {
+        $this->authorize('update', $project);
+
+        $sprint = $project->sprints()->create($request->validated());
+
+        return ApiResponse::success(['sprint' => $sprint], 201);
+    }
+
+    public function update(UpdateSprintRequest $request, Sprint $sprint)
+    {
+        $this->authorize('update', $sprint);
+
+        $sprint->update($request->validated());
+
+        return ApiResponse::success(['sprint' => $sprint->fresh()]);
+    }
+
+    public function destroy(Sprint $sprint)
+    {
+        $this->authorize('delete', $sprint);
+
+        $sprint->delete();
+
+        return ApiResponse::success(['deleted' => true]);
+    }
+
+    public function start(Sprint $sprint, SprintLifecycleService $lifecycle, NotificationService $notifications)
+    {
+        $this->authorize('update', $sprint);
+
+        $sprint = $lifecycle->start($sprint);
+        $notifications->sprintStarted($sprint, request()->user());
+
+        return ApiResponse::success(['sprint' => $sprint]);
+    }
+
+    public function complete(Sprint $sprint, SprintLifecycleService $lifecycle, IssueScheduler $scheduler, NotificationService $notifications)
+    {
+        $this->authorize('update', $sprint);
+
+        $sprint = $lifecycle->complete($sprint);
+
+        $issues = $sprint->issues()->get();
+        foreach ($issues as $issue) {
+            $scheduler->assignToBacklog($sprint->project, $issue);
+        }
+
+        $notifications->sprintCompleted($sprint, request()->user());
+
+        return ApiResponse::success(['sprint' => $sprint]);
+    }
+}

--- a/app/Http/Controllers/Api/SprintIssueController.php
+++ b/app/Http/Controllers/Api/SprintIssueController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ReorderSprintIssuesRequest;
+use App\Models\Issue;
+use App\Models\Sprint;
+use App\Services\IssueScheduler;
+use App\Support\ApiResponse;
+
+class SprintIssueController extends Controller
+{
+    public function reorder(ReorderSprintIssuesRequest $request, Sprint $sprint, IssueScheduler $scheduler)
+    {
+        $this->authorize('update', $sprint);
+
+        $data = $request->validated();
+        $issue = Issue::findOrFail($data['issue_id']);
+
+        $assignment = $scheduler->assignToSprint($sprint, $issue, $data['to_position']);
+
+        return ApiResponse::success(['sprint_item' => $assignment]);
+    }
+}

--- a/app/Http/Requests/ReorderBacklogRequest.php
+++ b/app/Http/Requests/ReorderBacklogRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderBacklogRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'issue_id' => ['required', 'uuid', 'exists:issues,id'],
+            'to_position' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/ReorderSprintIssuesRequest.php
+++ b/app/Http/Requests/ReorderSprintIssuesRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderSprintIssuesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'issue_id' => ['required', 'uuid', 'exists:issues,id'],
+            'to_position' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProjectMemberRequest.php
+++ b/app/Http/Requests/StoreProjectMemberRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProjectMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'uuid', 'exists:users,id'],
+            'role' => ['required', 'in:manager,contributor,viewer'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreSprintRequest.php
+++ b/app/Http/Requests/StoreSprintRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSprintRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'goal' => ['nullable', 'string'],
+            'starts_at' => ['nullable', 'date'],
+            'ends_at' => ['nullable', 'date'],
+            'status' => ['nullable', 'in:planned,active,completed'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProjectMemberRequest.php
+++ b/app/Http/Requests/UpdateProjectMemberRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProjectMemberRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role' => ['required', 'in:manager,contributor,viewer'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateSprintRequest.php
+++ b/app/Http/Requests/UpdateSprintRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateSprintRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'goal' => ['sometimes', 'nullable', 'string'],
+            'starts_at' => ['sometimes', 'nullable', 'date'],
+            'ends_at' => ['sometimes', 'nullable', 'date'],
+            'status' => ['sometimes', 'in:planned,active,completed'],
+        ];
+    }
+}

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Issue extends Model
 {
@@ -61,5 +62,17 @@ class Issue extends Model
     public function labels(): BelongsToMany
     {
         return $this->belongsToMany(Label::class, 'issue_label');
+    }
+
+    public function sprintAssignment(): HasOne
+    {
+        return $this->hasOne(IssueSprint::class);
+    }
+
+    public function sprints(): BelongsToMany
+    {
+        return $this->belongsToMany(Sprint::class, 'issue_sprint')
+            ->withPivot('position')
+            ->withTimestamps();
     }
 }

--- a/app/Models/IssueSprint.php
+++ b/app/Models/IssueSprint.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class IssueSprint extends Model
+{
+    protected $table = 'issue_sprint';
+
+    public $incrementing = false;
+
+    protected $primaryKey = 'issue_id';
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'issue_id',
+        'sprint_id',
+        'position',
+    ];
+
+    public function issue(): BelongsTo
+    {
+        return $this->belongsTo(Issue::class);
+    }
+
+    public function sprint(): BelongsTo
+    {
+        return $this->belongsTo(Sprint::class);
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\HasUuidPrimaryKey;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Notification extends Model
+{
+    use HasFactory, HasUuidPrimaryKey;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'type',
+        'payload',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'read_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Project extends Model
 {
@@ -30,5 +32,17 @@ class Project extends Model
     public function board(): HasOne
     {
         return $this->hasOne(Board::class);
+    }
+
+    public function sprints(): HasMany
+    {
+        return $this->hasMany(Sprint::class);
+    }
+
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'project_user')
+            ->withTimestamps()
+            ->withPivot('role');
     }
 }

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Concerns\HasUuidPrimaryKey;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Sprint extends Model
+{
+    use HasFactory, HasUuidPrimaryKey;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'project_id',
+        'name',
+        'goal',
+        'starts_at',
+        'ends_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function issues(): BelongsToMany
+    {
+        return $this->belongsToMany(Issue::class, 'issue_sprint')
+            ->withPivot('position')
+            ->withTimestamps();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,8 +5,11 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Models\Concerns\HasUuidPrimaryKey;
 use App\Models\Workspace;
+use App\Models\Project;
+use App\Models\Notification;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -60,5 +63,17 @@ class User extends Authenticatable
         return $this->belongsToMany(Workspace::class, 'workspace_user')
             ->withTimestamps()
             ->withPivot('role');
+    }
+
+    public function projects(): BelongsToMany
+    {
+        return $this->belongsToMany(Project::class, 'project_user')
+            ->withTimestamps()
+            ->withPivot('role');
+    }
+
+    public function notifications(): HasMany
+    {
+        return $this->hasMany(Notification::class);
     }
 }

--- a/app/Policies/BoardPolicy.php
+++ b/app/Policies/BoardPolicy.php
@@ -4,27 +4,27 @@ namespace App\Policies;
 
 use App\Models\Board;
 use App\Models\User;
-use App\Support\WorkspaceAccess;
+use App\Support\ProjectAccess;
 
 class BoardPolicy
 {
     public function view(User $user, Board $board): bool
     {
-        return WorkspaceAccess::isMember($user, $board->project->workspace);
+        return ProjectAccess::canViewProject($user, $board->project);
     }
 
     public function create(User $user, Board $board): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $board->project->workspace);
+        return ProjectAccess::canManageProject($user, $board->project);
     }
 
     public function update(User $user, Board $board): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $board->project->workspace);
+        return ProjectAccess::canManageProject($user, $board->project);
     }
 
     public function delete(User $user, Board $board): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $board->project->workspace);
+        return ProjectAccess::canManageProject($user, $board->project);
     }
 }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -4,17 +4,17 @@ namespace App\Policies;
 
 use App\Models\Comment;
 use App\Models\User;
-use App\Support\WorkspaceAccess;
+use App\Support\ProjectAccess;
 
 class CommentPolicy
 {
     public function create(User $user, Comment $comment): bool
     {
-        return WorkspaceAccess::isMember($user, $comment->issue->board->project->workspace);
+        return ProjectAccess::canManageIssues($user, $comment->issue->board->project);
     }
 
     public function delete(User $user, Comment $comment): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $comment->issue->board->project->workspace);
+        return ProjectAccess::canManageProject($user, $comment->issue->board->project);
     }
 }

--- a/app/Policies/IssuePolicy.php
+++ b/app/Policies/IssuePolicy.php
@@ -4,42 +4,42 @@ namespace App\Policies;
 
 use App\Models\Issue;
 use App\Models\User;
-use App\Support\WorkspaceAccess;
+use App\Support\ProjectAccess;
 
 class IssuePolicy
 {
     public function viewAny(User $user): bool
     {
-        return WorkspaceAccess::canManageAnyWorkspace($user);
+        return true;
     }
 
     public function view(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::isMember($user, $issue->board->project->workspace);
+        return ProjectAccess::canViewProject($user, $issue->board->project);
     }
 
     public function create(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::isMember($user, $issue->board->project->workspace);
+        return ProjectAccess::canManageIssues($user, $issue->board->project);
     }
 
     public function update(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::isMember($user, $issue->board->project->workspace);
+        return ProjectAccess::canManageIssues($user, $issue->board->project);
     }
 
     public function delete(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::isMember($user, $issue->board->project->workspace);
+        return ProjectAccess::canManageIssues($user, $issue->board->project);
     }
 
     public function move(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::isMember($user, $issue->board->project->workspace);
+        return ProjectAccess::canManageIssues($user, $issue->board->project);
     }
 
     public function assign(User $user, Issue $issue): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $issue->board->project->workspace);
+        return ProjectAccess::canManageProject($user, $issue->board->project);
     }
 }

--- a/app/Policies/NotificationPolicy.php
+++ b/app/Policies/NotificationPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Notification;
+use App\Models\User;
+
+class NotificationPolicy
+{
+    public function view(User $user, Notification $notification): bool
+    {
+        return $notification->user_id === $user->id;
+    }
+
+    public function update(User $user, Notification $notification): bool
+    {
+        return $notification->user_id === $user->id;
+    }
+}

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -4,27 +4,27 @@ namespace App\Policies;
 
 use App\Models\Project;
 use App\Models\User;
-use App\Support\WorkspaceAccess;
+use App\Support\ProjectAccess;
 
 class ProjectPolicy
 {
     public function view(User $user, Project $project): bool
     {
-        return WorkspaceAccess::isMember($user, $project->workspace);
+        return ProjectAccess::canViewProject($user, $project);
     }
 
     public function create(User $user, Project $project): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $project->workspace);
+        return ProjectAccess::canManageProject($user, $project);
     }
 
     public function update(User $user, Project $project): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $project->workspace);
+        return ProjectAccess::canManageProject($user, $project);
     }
 
     public function delete(User $user, Project $project): bool
     {
-        return WorkspaceAccess::canManageWorkspace($user, $project->workspace);
+        return ProjectAccess::canManageProject($user, $project);
     }
 }

--- a/app/Policies/SprintPolicy.php
+++ b/app/Policies/SprintPolicy.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Sprint;
+use App\Models\User;
+use App\Support\ProjectAccess;
+
+class SprintPolicy
+{
+    public function view(User $user, Sprint $sprint): bool
+    {
+        return ProjectAccess::canViewProject($user, $sprint->project);
+    }
+
+    public function create(User $user, Sprint $sprint): bool
+    {
+        return ProjectAccess::canManageProject($user, $sprint->project);
+    }
+
+    public function update(User $user, Sprint $sprint): bool
+    {
+        return ProjectAccess::canManageProject($user, $sprint->project);
+    }
+
+    public function delete(User $user, Sprint $sprint): bool
+    {
+        return ProjectAccess::canManageProject($user, $sprint->project);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\Activity;
+use App\Models\Notification;
 use App\Models\Workspace;
 use App\Policies\WorkspacePolicy;
 use App\Models\Project;
@@ -10,10 +11,13 @@ use App\Models\Board;
 use App\Models\BoardColumn;
 use App\Models\Label;
 use App\Models\Issue;
+use App\Models\Sprint;
 use App\Policies\ActivityPolicy;
 use App\Policies\BoardPolicy;
 use App\Policies\BoardColumnPolicy;
 use App\Policies\IssuePolicy;
+use App\Policies\NotificationPolicy;
+use App\Policies\SprintPolicy;
 use App\Policies\LabelPolicy;
 use App\Policies\ProjectPolicy;
 use Illuminate\Support\Facades\Gate;
@@ -41,5 +45,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(BoardColumn::class, BoardColumnPolicy::class);
         Gate::policy(Issue::class, IssuePolicy::class);
         Gate::policy(Label::class, LabelPolicy::class);
+        Gate::policy(Sprint::class, SprintPolicy::class);
+        Gate::policy(Notification::class, NotificationPolicy::class);
     }
 }

--- a/app/Services/IssueScheduler.php
+++ b/app/Services/IssueScheduler.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Issue;
+use App\Models\IssueSprint;
+use App\Models\Project;
+use App\Models\Sprint;
+use Illuminate\Support\Facades\DB;
+
+class IssueScheduler
+{
+    public function assignToBacklog(Project $project, Issue $issue, ?int $toPosition = null): IssueSprint
+    {
+        return DB::transaction(function () use ($project, $issue, $toPosition) {
+            $this->ensureProjectIssue($project, $issue);
+
+            $current = IssueSprint::where('issue_id', $issue->id)->first();
+            $currentSprintId = $current?->sprint_id;
+
+            $maxPosition = $this->backlogQuery($issue->board_id)
+                ->max('issue_sprint.position') ?? 0;
+
+            $targetPosition = $toPosition ?? ($maxPosition + 1);
+            $targetPosition = max(1, min($targetPosition, $maxPosition + 1));
+
+            if ($currentSprintId === null && $current) {
+                return $this->moveWithinBacklog($project, $issue, $targetPosition);
+            }
+
+            if ($current) {
+                $this->closeGap($currentSprintId, $current->position, $issue->board_id);
+                $current->update(['sprint_id' => null, 'position' => $targetPosition]);
+            } else {
+                IssueSprint::create([
+                    'issue_id' => $issue->id,
+                    'sprint_id' => null,
+                    'position' => $targetPosition,
+                ]);
+            }
+
+            $this->backlogQuery($issue->board_id)
+                ->where('issue_sprint.issue_id', '!=', $issue->id)
+                ->where('issue_sprint.position', '>=', $targetPosition)
+                ->increment('issue_sprint.position');
+
+            return IssueSprint::where('issue_id', $issue->id)->firstOrFail();
+        });
+    }
+
+    public function assignToSprint(Sprint $sprint, Issue $issue, ?int $toPosition = null): IssueSprint
+    {
+        return DB::transaction(function () use ($sprint, $issue, $toPosition) {
+            $this->ensureProjectIssue($sprint->project, $issue);
+
+            $current = IssueSprint::where('issue_id', $issue->id)->first();
+            $currentSprintId = $current?->sprint_id;
+
+            $maxPosition = IssueSprint::where('sprint_id', $sprint->id)->max('position') ?? 0;
+            $targetPosition = $toPosition ?? ($maxPosition + 1);
+            $targetPosition = max(1, min($targetPosition, $maxPosition + 1));
+
+            if ($currentSprintId === $sprint->id && $current) {
+                return $this->moveWithinSprint($sprint, $issue, $targetPosition);
+            }
+
+            if ($current) {
+                $this->closeGap($currentSprintId, $current->position, $issue->board_id);
+                $current->update(['sprint_id' => $sprint->id, 'position' => $targetPosition]);
+            } else {
+                IssueSprint::create([
+                    'issue_id' => $issue->id,
+                    'sprint_id' => $sprint->id,
+                    'position' => $targetPosition,
+                ]);
+            }
+
+            IssueSprint::where('sprint_id', $sprint->id)
+                ->where('issue_id', '!=', $issue->id)
+                ->where('position', '>=', $targetPosition)
+                ->increment('position');
+
+            return IssueSprint::where('issue_id', $issue->id)->firstOrFail();
+        });
+    }
+
+    public function moveWithinBacklog(Project $project, Issue $issue, int $toPosition): IssueSprint
+    {
+        return DB::transaction(function () use ($project, $issue, $toPosition) {
+            $this->ensureProjectIssue($project, $issue);
+
+            $current = IssueSprint::where('issue_id', $issue->id)->first();
+            if (! $current || $current->sprint_id !== null) {
+                return $this->assignToBacklog($project, $issue, $toPosition);
+            }
+
+            $maxPosition = $this->backlogQuery($issue->board_id)
+                ->max('issue_sprint.position') ?? 0;
+
+            $targetPosition = max(1, min($toPosition, $maxPosition));
+
+            if ($targetPosition === $current->position) {
+                return $current->fresh();
+            }
+
+            $this->shiftPositions(null, $current->position, $targetPosition, $issue->board_id);
+
+            $current->update(['position' => $targetPosition]);
+
+            return $current->fresh();
+        });
+    }
+
+    public function moveWithinSprint(Sprint $sprint, Issue $issue, int $toPosition): IssueSprint
+    {
+        return DB::transaction(function () use ($sprint, $issue, $toPosition) {
+            $this->ensureProjectIssue($sprint->project, $issue);
+
+            $current = IssueSprint::where('issue_id', $issue->id)->first();
+            if (! $current || $current->sprint_id !== $sprint->id) {
+                return $this->assignToSprint($sprint, $issue, $toPosition);
+            }
+
+            $maxPosition = IssueSprint::where('sprint_id', $sprint->id)->max('position') ?? 0;
+            $targetPosition = max(1, min($toPosition, $maxPosition));
+
+            if ($targetPosition === $current->position) {
+                return $current->fresh();
+            }
+
+            $this->shiftPositions($sprint->id, $current->position, $targetPosition);
+
+            $current->update(['position' => $targetPosition]);
+
+            return $current->fresh();
+        });
+    }
+
+    protected function shiftPositions(?string $sprintId, int $fromPosition, int $toPosition, ?string $boardId = null): void
+    {
+        if ($sprintId === null && $boardId) {
+            $query = $this->backlogQuery($boardId);
+        } else {
+            $query = IssueSprint::where('sprint_id', $sprintId);
+        }
+
+        if ($toPosition < $fromPosition) {
+            $query->whereBetween('issue_sprint.position', [$toPosition, $fromPosition - 1])
+                ->increment('issue_sprint.position');
+        } else {
+            $query->whereBetween('issue_sprint.position', [$fromPosition + 1, $toPosition])
+                ->decrement('issue_sprint.position');
+        }
+    }
+
+    protected function closeGap(?string $sprintId, int $fromPosition, ?string $boardId = null): void
+    {
+        if ($sprintId === null && $boardId) {
+            $this->backlogQuery($boardId)
+                ->where('issue_sprint.position', '>', $fromPosition)
+                ->decrement('issue_sprint.position');
+            return;
+        }
+
+        IssueSprint::where('sprint_id', $sprintId)
+            ->where('position', '>', $fromPosition)
+            ->decrement('position');
+    }
+
+    protected function backlogQuery(string $boardId)
+    {
+        return IssueSprint::whereNull('sprint_id')
+            ->join('issues', 'issue_sprint.issue_id', '=', 'issues.id')
+            ->where('issues.board_id', $boardId);
+    }
+
+    protected function ensureProjectIssue(Project $project, Issue $issue): void
+    {
+        if ($issue->board->project_id !== $project->id) {
+            throw new \InvalidArgumentException('Issue does not belong to project.');
+        }
+    }
+}

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Issue;
+use App\Models\Notification;
+use App\Models\Project;
+use App\Models\Sprint;
+use App\Models\User;
+
+class NotificationService
+{
+    public function issueAssigned(User $assignee, Issue $issue, User $actor): ?Notification
+    {
+        if ($assignee->id === $actor->id) {
+            return null;
+        }
+
+        return $this->create($assignee, 'issue.assigned', [
+            'issue_id' => $issue->id,
+            'board_id' => $issue->board_id,
+            'actor_id' => $actor->id,
+        ]);
+    }
+
+    public function issueMovedToDone(Issue $issue, User $actor): ?Notification
+    {
+        $assignee = $issue->assignee;
+        if (! $assignee || $assignee->id === $actor->id) {
+            return null;
+        }
+
+        return $this->create($assignee, 'issue.done', [
+            'issue_id' => $issue->id,
+            'board_id' => $issue->board_id,
+            'actor_id' => $actor->id,
+        ]);
+    }
+
+    public function issueCommented(Issue $issue, User $actor): ?Notification
+    {
+        $assignee = $issue->assignee;
+        if (! $assignee || $assignee->id === $actor->id) {
+            return null;
+        }
+
+        return $this->create($assignee, 'issue.commented', [
+            'issue_id' => $issue->id,
+            'board_id' => $issue->board_id,
+            'actor_id' => $actor->id,
+        ]);
+    }
+
+    /**
+     * @return array<int, Notification>
+     */
+    public function sprintStarted(Sprint $sprint, User $actor): array
+    {
+        return $this->notifyProjectMembers($sprint->project, 'sprint.started', [
+            'sprint_id' => $sprint->id,
+            'project_id' => $sprint->project_id,
+            'actor_id' => $actor->id,
+        ]);
+    }
+
+    /**
+     * @return array<int, Notification>
+     */
+    public function sprintCompleted(Sprint $sprint, User $actor): array
+    {
+        return $this->notifyProjectMembers($sprint->project, 'sprint.completed', [
+            'sprint_id' => $sprint->id,
+            'project_id' => $sprint->project_id,
+            'actor_id' => $actor->id,
+        ]);
+    }
+
+    protected function create(User $user, string $type, array $payload): Notification
+    {
+        return Notification::create([
+            'user_id' => $user->id,
+            'type' => $type,
+            'payload' => $payload,
+        ]);
+    }
+
+    /**
+     * @return array<int, Notification>
+     */
+    protected function notifyProjectMembers(Project $project, string $type, array $payload): array
+    {
+        $members = $project->members()->get();
+
+        if ($members->isEmpty()) {
+            $members = $project->workspace->members()->get();
+        }
+
+        return $members->map(function (User $user) use ($type, $payload) {
+            return $this->create($user, $type, $payload);
+        })->all();
+    }
+}

--- a/app/Services/SprintLifecycleService.php
+++ b/app/Services/SprintLifecycleService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Sprint;
+use Illuminate\Support\Facades\DB;
+
+class SprintLifecycleService
+{
+    public function start(Sprint $sprint): Sprint
+    {
+        return DB::transaction(function () use ($sprint) {
+            $sprint->project->sprints()
+                ->where('status', 'active')
+                ->where('id', '!=', $sprint->id)
+                ->update(['status' => 'completed', 'ends_at' => now()]);
+
+            $sprint->update([
+                'status' => 'active',
+                'starts_at' => $sprint->starts_at ?? now(),
+            ]);
+
+            return $sprint->fresh();
+        });
+    }
+
+    public function complete(Sprint $sprint): Sprint
+    {
+        $sprint->update([
+            'status' => 'completed',
+            'ends_at' => $sprint->ends_at ?? now(),
+        ]);
+
+        return $sprint->fresh();
+    }
+}

--- a/app/Support/ProjectAccess.php
+++ b/app/Support/ProjectAccess.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Project;
+use App\Models\User;
+
+class ProjectAccess
+{
+    public static function role(User $user, Project $project): ?string
+    {
+        if ($project->relationLoaded('members')) {
+            $member = $project->members->firstWhere('id', $user->id);
+            return $member?->pivot?->role;
+        }
+
+        return $project->members()
+            ->where('user_id', $user->id)
+            ->value('role');
+    }
+
+    public static function canManageProject(User $user, Project $project): bool
+    {
+        $role = self::role($user, $project);
+
+        if (in_array($role, ['manager'], true)) {
+            return true;
+        }
+
+        return WorkspaceAccess::canManageWorkspace($user, $project->workspace);
+    }
+
+    public static function canManageIssues(User $user, Project $project): bool
+    {
+        $role = self::role($user, $project);
+
+        if (in_array($role, ['manager', 'contributor'], true)) {
+            return true;
+        }
+
+        return WorkspaceAccess::isMember($user, $project->workspace);
+    }
+
+    public static function canViewProject(User $user, Project $project): bool
+    {
+        $role = self::role($user, $project);
+
+        if ($role !== null) {
+            return true;
+        }
+
+        return WorkspaceAccess::isMember($user, $project->workspace);
+    }
+}

--- a/database/factories/SprintFactory.php
+++ b/database/factories/SprintFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use App\Models\Sprint;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Sprint>
+ */
+class SprintFactory extends Factory
+{
+    protected $model = Sprint::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'name' => 'Sprint '.fake()->word(),
+            'goal' => fake()->sentence(),
+            'starts_at' => null,
+            'ends_at' => null,
+            'status' => 'planned',
+        ];
+    }
+}

--- a/database/migrations/2026_01_05_000000_create_sprints_table.php
+++ b/database/migrations/2026_01_05_000000_create_sprints_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sprints', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('project_id')->constrained('projects')->cascadeOnDelete();
+            $table->string('name');
+            $table->text('goal')->nullable();
+            $table->dateTime('starts_at')->nullable();
+            $table->dateTime('ends_at')->nullable();
+            $table->string('status')->default('planned');
+            $table->timestamps();
+
+            $table->index(['project_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sprints');
+    }
+};

--- a/database/migrations/2026_01_05_000100_create_issue_sprint_table.php
+++ b/database/migrations/2026_01_05_000100_create_issue_sprint_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('issue_sprint', function (Blueprint $table) {
+            $table->foreignUuid('issue_id')->primary()->constrained('issues')->cascadeOnDelete();
+            $table->foreignUuid('sprint_id')->nullable()->constrained('sprints')->nullOnDelete();
+            $table->integer('position')->default(0);
+            $table->timestamps();
+
+            $table->index(['sprint_id', 'position']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('issue_sprint');
+    }
+};

--- a/database/migrations/2026_01_05_000150_backfill_issue_sprint_table.php
+++ b/database/migrations/2026_01_05_000150_backfill_issue_sprint_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('issue_sprint')) {
+            return;
+        }
+
+        $issues = DB::table('issues')
+            ->select('id', 'board_id', 'created_at')
+            ->orderBy('created_at')
+            ->get()
+            ->groupBy('board_id');
+
+        foreach ($issues as $boardId => $boardIssues) {
+            $position = 1;
+            foreach ($boardIssues as $issue) {
+                $exists = DB::table('issue_sprint')
+                    ->where('issue_id', $issue->id)
+                    ->exists();
+
+                if ($exists) {
+                    continue;
+                }
+
+                DB::table('issue_sprint')->insert([
+                    'issue_id' => $issue->id,
+                    'sprint_id' => null,
+                    'position' => $position,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                $position++;
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No-op: historical ordering data should be preserved.
+    }
+};

--- a/database/migrations/2026_01_05_000200_create_project_user_table.php
+++ b/database/migrations/2026_01_05_000200_create_project_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('project_user', function (Blueprint $table) {
+            $table->foreignUuid('project_id')->constrained('projects')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('role')->default('contributor');
+            $table->timestamps();
+
+            $table->primary(['project_id', 'user_id']);
+            $table->index(['project_id', 'role']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_user');
+    }
+};

--- a/database/migrations/2026_01_05_000300_create_notifications_table.php
+++ b/database/migrations/2026_01_05_000300_create_notifications_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('type');
+            $table->json('payload');
+            $table->dateTime('read_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'read_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,11 @@ use App\Http\Controllers\Api\IssueCommentController;
 use App\Http\Controllers\Api\IssueLabelController;
 use App\Http\Controllers\Api\ActivityController;
 use App\Http\Controllers\Api\LabelController;
+use App\Http\Controllers\Api\SprintController;
+use App\Http\Controllers\Api\SprintIssueController;
+use App\Http\Controllers\Api\BacklogController;
+use App\Http\Controllers\Api\ProjectMemberController;
+use App\Http\Controllers\Api\NotificationController;
 
 Route::get('/user', function (Request $request) {
     return ApiResponse::success(['user' => $request->user()]);
@@ -32,6 +37,20 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/projects/{project}/board', [BoardController::class, 'show']);
     Route::post('/projects/{project}/board', [BoardController::class, 'store']);
+
+    Route::get('/projects/{project}/sprints', [SprintController::class, 'index']);
+    Route::post('/projects/{project}/sprints', [SprintController::class, 'store']);
+    Route::patch('/sprints/{sprint}', [SprintController::class, 'update']);
+    Route::delete('/sprints/{sprint}', [SprintController::class, 'destroy']);
+    Route::post('/sprints/{sprint}/start', [SprintController::class, 'start']);
+    Route::post('/sprints/{sprint}/complete', [SprintController::class, 'complete']);
+    Route::post('/projects/{project}/backlog/reorder', [BacklogController::class, 'reorder']);
+    Route::post('/sprints/{sprint}/issues/reorder', [SprintIssueController::class, 'reorder']);
+
+    Route::get('/projects/{project}/members', [ProjectMemberController::class, 'index']);
+    Route::post('/projects/{project}/members', [ProjectMemberController::class, 'store']);
+    Route::patch('/projects/{project}/members/{user}', [ProjectMemberController::class, 'update']);
+    Route::delete('/projects/{project}/members/{user}', [ProjectMemberController::class, 'destroy']);
 
     Route::get('/boards/{board}/columns', [BoardColumnController::class, 'index']);
     Route::post('/boards/{board}/columns', [BoardColumnController::class, 'store']);
@@ -54,4 +73,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/issues/{issue}/comments', [IssueCommentController::class, 'store']);
 
     Route::get('/workspaces/{workspace}/activities', [ActivityController::class, 'index']);
+
+    Route::get('/notifications', [NotificationController::class, 'index']);
+    Route::post('/notifications/{notification}/read', [NotificationController::class, 'read']);
+    Route::post('/notifications/read-all', [NotificationController::class, 'readAll']);
 });

--- a/tests/Feature/Phase4SprintNotificationsTest.php
+++ b/tests/Feature/Phase4SprintNotificationsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\IssueScheduler;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function createProjectWithBoardAndColumns(User $user): array
+{
+    $workspace = Workspace::factory()->create([
+        'owner_id' => $user->id,
+    ]);
+
+    $workspace->members()->syncWithoutDetaching([
+        $user->id => ['role' => 'owner'],
+    ]);
+
+    $project = Project::factory()->create([
+        'workspace_id' => $workspace->id,
+    ]);
+
+    $board = $project->board()->create(['name' => 'Main Board']);
+    $columns = collect([
+        ['name' => 'Todo', 'key' => 'todo', 'position' => 1],
+        ['name' => 'Done', 'key' => 'done', 'position' => 2],
+    ])->map(fn (array $data) => $board->columns()->create($data));
+
+    return [$workspace, $project, $board, $columns];
+}
+
+it('starts a sprint and completes any active sprint in the project', function () {
+    $user = User::factory()->create();
+    [, $project] = createProjectWithBoardAndColumns($user);
+
+    $active = $project->sprints()->create([
+        'name' => 'Active Sprint',
+        'status' => 'active',
+    ]);
+
+    $newSprint = $project->sprints()->create([
+        'name' => 'New Sprint',
+        'status' => 'planned',
+    ]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/sprints/{$newSprint->id}/start")
+        ->assertStatus(200)
+        ->assertJsonPath('data.sprint.status', 'active');
+
+    $active->refresh();
+    expect($active->status)->toBe('completed');
+});
+
+it('enforces column wip limits on issue creation', function () {
+    $user = User::factory()->create();
+    [, , $board, $columns] = createProjectWithBoardAndColumns($user);
+    $todoColumn = $columns->firstWhere('key', 'todo');
+    $todoColumn->update(['wip_limit' => 1]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/boards/{$board->id}/issues", [
+            'title' => 'First',
+            'column_id' => $todoColumn->id,
+        ])
+        ->assertStatus(201);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/boards/{$board->id}/issues", [
+            'title' => 'Second',
+            'column_id' => $todoColumn->id,
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('error.code', 'wip_limit_reached');
+});
+
+it('creates notifications for issue assignment', function () {
+    $owner = User::factory()->create();
+    $assignee = User::factory()->create();
+    [, , $board, $columns] = createProjectWithBoardAndColumns($owner);
+    $todoColumn = $columns->firstWhere('key', 'todo');
+
+    $board->project->members()->syncWithoutDetaching([
+        $assignee->id => ['role' => 'contributor'],
+    ]);
+
+    $issue = $board->issues()->create([
+        'title' => 'Assign me',
+        'column_id' => $todoColumn->id,
+        'position' => 1,
+    ]);
+
+    app(IssueScheduler::class)->assignToBacklog($board->project, $issue);
+
+    $this->actingAs($owner, 'sanctum')
+        ->postJson("/api/issues/{$issue->id}/assign", [
+            'assignee_id' => $assignee->id,
+        ])
+        ->assertStatus(200);
+
+    $notification = $assignee->notifications()->first();
+    expect($notification)->not->toBeNull()
+        ->and($notification->type)->toBe('issue.assigned');
+});


### PR DESCRIPTION
## Summary
- Add sprints/backlog schema and issue scheduling with ordering support
- Add WIP limit enforcement, project-level permissions, and in-app notifications
- Add sprint/backlog/member/notification APIs and supporting services
- Add Filament resources for sprints, project members, and notifications
- Add initial Phase 4 feature tests

## Checklist
- [x] migrations added (if needed)
- [x] policies/authorization reviewed
- [x] tests added or updated
- [x] documentation updated

## Sample API responses
- GET /api/projects/{project}/sprints returns sprint list
- POST /api/sprints/{sprint}/start activates sprint and completes any active sprint
- POST /api/notifications/{notification}/read marks notification read

## Notes for reviewers
- Backlog ordering is stored in issue_sprint with sprint_id null
- WIP limits enforced on issue create/move/update
- Notifications are stored in the notifications table

Closes #3